### PR TITLE
Update operator start command instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ make start-aggregator
 Register the operator with eigenlayer and incredible-squaring, and then start the process:
 
 ```bash
-make cli-setup-operator
 make start-operator
 ```
+
+> By default, the `start-operator` command will also setup the operator (see `register_operator_on_startup` flag in `config-files/operator.anvil.yaml`). To disable this, set `register_operator_on_startup` to false, and run `make cli-setup-operator` before running `start-operator`.
 
 ## Running via docker compose
 


### PR DESCRIPTION
As configured now, the `make start-operator` command will fail because `make start-operator` also re-runs the `register` operation, these instructions hopefully make the setup process easier.