### PR TITLE
<Fix>  Print the specific error reason for "registering operator".

### DIFF
--- a/operator/registration.go
+++ b/operator/registration.go
@@ -56,7 +56,7 @@ func (o *Operator) RegisterOperatorWithEigenlayer() error {
 	}
 	_, err := o.eigenlayerWriter.RegisterAsOperator(context.Background(), op)
 	if err != nil {
-		o.logger.Errorf("Error registering operator with eigenlayer")
+		o.logger.Error("Error registering operator with eigenlayer", "err", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION

When executing `make cli-setup-operator,` the specific reason for registering the operator is not printed out.