### PR TITLE
add delay in start-anvil-chain-with-el-and-avs-deployed.sh

### DIFF
--- a/tests/anvil/start-anvil-chain-with-el-and-avs-deployed.sh
+++ b/tests/anvil/start-anvil-chain-with-el-and-avs-deployed.sh
@@ -18,6 +18,7 @@ cd ../../contracts
 # so calling getOperatorListAtBlockNumber reverts because it thinks there are no quorums registered at block 0
 # advancing chain manually like this is a current hack until https://github.com/foundry-rs/foundry/issues/6679 is merged
 # also not that it doesn't really advance by the correct number of blocks.. not sure why, so we just forward by a bunch of blocks that should be enough
+sleep 1
 forge script script/utils/Utils.sol --sig "advanceChainByNBlocks(uint256)" 100 --rpc-url $RPC_URL  --private-key $PRIVATE_KEY --broadcast
 echo "current block-number:" $(cast block-number)
 


### PR DESCRIPTION
the `forge script script/utils/Utils.sol --sig "advanceChainByNBlocks(uint256)" 100 --rpc-url $RPC_URL  --private-key $PRIVATE_KEY --broadcast` may execute failed some time, add `sleep 1` to ensure the anvil is ready