### PR TITLE
add sleep to fix run issue from new saved state 

### DIFF
--- a/tests/anvil/start-anvil-chain-with-el-and-avs-deployed.sh
+++ b/tests/anvil/start-anvil-chain-with-el-and-avs-deployed.sh
@@ -12,6 +12,7 @@ cd "$parent_path"
 anvil --load-state avs-and-eigenlayer-deployed-anvil-state.json &
 ANVIL_PID=$!
 
+sleep 5 
 cd ../../contracts
 # we need to restart the anvil chain at the correct block, otherwise the indexRegistry has a quorumUpdate at the block number
 # at which it was deployed (aka quorum was created/updated), but when we start anvil by loading state file it starts at block number 0


### PR DESCRIPTION
Running `make start-anvil-chain-with-el-and-avs-deployed` command with existing json state works fine. 

However, if one wishes to deploy their modified contracts to produce a new tests/anvil/avs-and-eigenlayer-deployed-anvil-state.json file by running the `make deploy-incredible-squaring-contracts-to-anvil-and-save-state` first , and then when wish to run again from the saved json using the original make command `make start-anvil-chain-with-el-and-avs-deployed` produces this error:

![image](https://github.com/Layr-Labs/incredible-squaring-avs/assets/91819504/f179de5b-93e1-4162-af45-61197b5135c9)

The fix is to simply sleep for few seconds after loading the json state before making any calls to the node. 

