### PR TITLE
dockerize anvil and pin at non-buggy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@ Basic repo demoing a simple AVS middleware with full eigenlayer integration. See
 
 ## Dependencies
 
-You will need [foundry](https://book.getfoundry.sh/getting-started/installation) and [zap-pretty](https://github.com/maoueh/zap-pretty) to run the examples below.
+You will need [foundry](https://book.getfoundry.sh/getting-started/installation) and [zap-pretty](https://github.com/maoueh/zap-pretty) and docker to run the examples below.
 ```
 curl -L https://foundry.paradigm.xyz | bash
 foundryup
 go install github.com/maoueh/zap-pretty@latest
 ```
-
-Also make sure to build the contracts:
+You will also need to [install docker](https://docs.docker.com/get-docker/), and build the contracts:
 ```
 make build-contracts
 ```

--- a/tests/anvil/start-anvil-chain-with-el-and-avs-deployed.sh
+++ b/tests/anvil/start-anvil-chain-with-el-and-avs-deployed.sh
@@ -9,8 +9,11 @@ cd "$parent_path"
 
 # start an anvil instance in the background that has eigenlayer contracts deployed
 # we start anvil in the background so that we can run the below script
-anvil --load-state avs-and-eigenlayer-deployed-anvil-state.json &
+# anvil --load-state avs-and-eigenlayer-deployed-anvil-state.json &
+# FIXME: bug in latest foundry version, so we use this pinned version instead of latest
+docker run -p 8545:8545 -v $(pwd)/avs-and-eigenlayer-deployed-anvil-state.json:/avs-and-eigenlayer-deployed-anvil-state.json --entrypoint anvil ghcr.io/foundry-rs/foundry:nightly-de33b6af53005037b463318d2628b5cfcaf39916 --load-state /avs-and-eigenlayer-deployed-anvil-state.json --host 0.0.0.0 &
 ANVIL_PID=$!
+sleep 2
 
 cd ../../contracts
 # we need to restart the anvil chain at the correct block, otherwise the indexRegistry has a quorumUpdate at the block number


### PR DESCRIPTION
This addresses issue #34 

Ideally foundry will solve this bug, and we'll be able to use latest version again to get nightly improvements. But for now, we'll stick to pinning anvil version that works.