### PR TITLE
fixed operator docker config file

### DIFF
--- a/config-files/operator-docker-compose.anvil.yaml
+++ b/config-files/operator-docker-compose.anvil.yaml
@@ -5,11 +5,11 @@ operator_address: 0x860B6912C2d0337ef05bbC89b0C2CB6CbAEAB4A5
 
 # EigenLayer Slasher contract address
 
-# This is the address of the slasher which is deployed in the anvil saved state
-# The saved eigenlayer state is located in tests/anvil/eigenlayer-deployed-anvil-state.json
-el_slasher_address: 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707
-avs_service_manager_address: 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690
-bls_operator_state_retriever_address: 0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f
+# This is the address of the contracts which are deployed in the anvil saved state
+# The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
+# TODO(samlaf): automate updating these addresses when we deploy new contracts
+avs_registry_coordinator_address: 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690
+operator_state_retriever_address: 0x1613beB3B2C4f22Ee086B2b38C1476A3cE7f78E8
 
 # ETH RPC URL
 eth_rpc_url: http://anvil:8545

--- a/config-files/operator.anvil.yaml
+++ b/config-files/operator.anvil.yaml
@@ -5,7 +5,7 @@ operator_address: 0x860B6912C2d0337ef05bbC89b0C2CB6CbAEAB4A5
 
 # EigenLayer Slasher contract address
 
-# This is the address of the slasher which is deployed in the anvil saved state
+# This is the address of the contracts which are deployed in the anvil saved state
 # The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
 # TODO(samlaf): automate updating these addresses when we deploy new contracts
 avs_registry_coordinator_address: 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690
@@ -29,6 +29,7 @@ ecdsa_private_key_store_path: tests/keys/test.ecdsa.key.json
 # If you are running locally using go run main.go, this should be full path to your local bls key file
 bls_private_key_store_path: tests/keys/test.bls.key.json
 
+# address which the aggregator listens on for operator signed messages
 aggregator_server_ip_port_address: localhost:8090
 
 # avs node spec compliance https://eigen.nethermind.io/docs/spec/intro


### PR DESCRIPTION
fixes #37 

aggregator still fails in docker-compose because need to advance state of the chain... or wait for anvil to fix their --load-state option. Will create a separate issue.