### PR TITLE
add new docker compose up test ci workflow

### DIFF
--- a/.github/workflows/docker-compose-up-test.yaml
+++ b/.github/workflows/docker-compose-up-test.yaml
@@ -1,0 +1,38 @@
+name: Docker Compose Up Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docker-compose-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Run Docker Compose
+        run: docker compose up
+
+      - name: Sleep
+        run: sleep 60
+
+      - name: Check services running
+        run: |
+          if docker compose ps -aq | xargs docker inspect -f '{{ .State.Status }}' | grep -v running; then
+            echo "Some services are not running"
+            exit 1
+          fi
+
+      # TODO: we should also add https://docs.docker.com/reference/dockerfile/#healthcheck to the aggregator and operator docker images
+      #       then we could check on their health status (maybe the processes are still running, but they are logging a lot of errors and we want to catch that)
+      # - name: Check services health
+      #   run: |
+      #     if docker-compose -f docker-compose.yml ps -q | xargs docker inspect -f '{{ .State.Health.Status }}' | grep -v healthy; then
+      #       echo "Some services are not healthy"
+      #       exit 1
+      #     fi


### PR DESCRIPTION
Goal here is to catch docker-compose up failing when we update things and forget to update it.
See for eg #39 