### PR TITLE
refactor: aggregator uses flags instead of config-file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ help:
 AGGREGATOR_ECDSA_PRIV_KEY=0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6
 CHALLENGER_ECDSA_PRIV_KEY=0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
 
+ETH_RPC_URL=http://localhost:8545
+ETH_WS_URL=ws://localhost:8545
+
+AGGREGATOR_SERVER_IP_PORT_ADDRESS=localhost:8090
+
 CHAINID=31337
 # Make sure to update this if the strategy address changes
 # check in contracts/script/output/${CHAINID}/credible_squaring_avs_deployment_output.json
@@ -68,7 +73,10 @@ send-fund: ## sends fund to the operator saved in tests/keys/test.ecdsa.key.json
 # TODO: piping to zap-pretty only works when zapper environment is set to production, unsure why
 ____OFFCHAIN_SOFTWARE___: ## 
 start-aggregator: ## 
-	go run aggregator/cmd/main.go --config config-files/aggregator.yaml \
+	go run aggregator/cmd/main.go --environment production \
+		--eth-rpc-url ${ETH_RPC_URL} \
+		--eth-ws-url ${ETH_WS_URL} \
+		--aggregator-server-ip-port-address ${AGGREGATOR_SERVER_IP_PORT_ADDRESS} \
 		--credible-squaring-deployment ${DEPLOYMENT_FILES_DIR}/credible_squaring_avs_deployment_output.json \
 		--ecdsa-private-key ${AGGREGATOR_ECDSA_PRIV_KEY} \
 		2>&1 | zap-pretty

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -61,15 +61,31 @@ type IncredibleSquaringContractsRaw struct {
 	OperatorStateRetrieverAddr string `json:"operatorStateRetriever"`
 }
 
-// NewConfig parses config file to read from from flags or environment variables
+// NewConfig parses config file to read from flags or environment variables
 // Note: This config is shared by challenger and aggregator and so we put in the core.
 // Operator has a different config and is meant to be used by the operator CLI.
 func NewConfig(ctx *cli.Context) (*Config, error) {
 
 	var configRaw ConfigRaw
-	configFilePath := ctx.GlobalString(ConfigFileFlag.Name)
-	if configFilePath != "" {
-		sdkutils.ReadYamlConfig(configFilePath, &configRaw)
+
+	environment := ctx.GlobalString(EnvironmentFlag.Name)
+	if environment != "" {
+		configRaw.Environment = sdklogging.LogLevel(environment)
+	}
+
+	ethRpcUrl := ctx.GlobalString(EthRpcUrlFlag.Name)
+	if ethRpcUrl != "" {
+		configRaw.EthRpcUrl = ethRpcUrl
+	}
+
+	ethWsUrl := ctx.GlobalString(EthWsUrlFlag.Name)
+	if ethWsUrl != "" {
+		configRaw.EthWsUrl = ethWsUrl
+	}
+
+	aggregatorServerIpPortAddr := ctx.GlobalString(AggregatorServerIpPortAddressFlag.Name)
+	if aggregatorServerIpPortAddr != "" {
+		configRaw.AggregatorServerIpPortAddr = aggregatorServerIpPortAddr
 	}
 
 	var credibleSquaringDeploymentRaw IncredibleSquaringDeploymentRaw
@@ -164,6 +180,26 @@ var (
 		Required: true,
 		Usage:    "Load configuration from `FILE`",
 	}
+	EnvironmentFlag = cli.StringFlag{
+		Name:     "environment",
+		Required: true,
+		Usage:    "Set the environment (production or development)",
+	}
+	EthRpcUrlFlag = cli.StringFlag{
+		Name:     "eth-rpc-url",
+		Required: true,
+		Usage:    "Ethereum RPC URL",
+	}
+	EthWsUrlFlag = cli.StringFlag{
+		Name:     "eth-ws-url",
+		Required: true,
+		Usage:    "Ethereum WS URL",
+	}
+	AggregatorServerIpPortAddressFlag = cli.StringFlag{
+		Name:     "aggregator-server-ip-port-address",
+		Required: true,
+		Usage:    "Aggregator server IP PORT address",
+	}
 	CredibleSquaringDeploymentFileFlag = cli.StringFlag{
 		Name:     "credible-squaring-deployment",
 		Required: true,
@@ -179,7 +215,10 @@ var (
 )
 
 var requiredFlags = []cli.Flag{
-	ConfigFileFlag,
+	EnvironmentFlag,
+	EthRpcUrlFlag,
+	EthWsUrlFlag,
+	AggregatorServerIpPortAddressFlag,
 	CredibleSquaringDeploymentFileFlag,
 	EcdsaPrivateKeyFlag,
 }


### PR DESCRIPTION
Refactored the aggregator such that `make start-aggregator` uses flags instead of config-files for the following variables:
```yaml
# 'production' only prints info and above. 'development' also prints debug
environment: production
eth_rpc_url: http://localhost:8545
eth_ws_url: ws://localhost:8545
# address which the aggregator listens on for operator signed messages
aggregator_server_ip_port_address: localhost:8090
```

Question: Should I delete the `config-files/aggregator.yaml` file ?