### PR TITLE
feat: eigenlayer-middleware v0.2.1

### DIFF
--- a/contracts/script/IncredibleSquaringDeployer.s.sol
+++ b/contracts/script/IncredibleSquaringDeployer.s.sol
@@ -17,7 +17,7 @@ import {BLSApkRegistry} from "@eigenlayer-middleware/src/BLSApkRegistry.sol";
 import {IndexRegistry} from "@eigenlayer-middleware/src/IndexRegistry.sol";
 import {StakeRegistry} from "@eigenlayer-middleware/src/StakeRegistry.sol";
 import "@eigenlayer-middleware/src/OperatorStateRetriever.sol";
-
+import {IRewardsCoordinator} from "@eigenlayer/contracts/interfaces/IRewardsCoordinator.sol";
 import {IncredibleSquaringServiceManager, IServiceManager} from "../src/IncredibleSquaringServiceManager.sol";
 import {IncredibleSquaringTaskManager} from "../src/IncredibleSquaringTaskManager.sol";
 import {IIncredibleSquaringTaskManager} from "../src/IIncredibleSquaringTaskManager.sol";
@@ -86,6 +86,8 @@ contract IncredibleSquaringDeployer is Script, Utils {
         StrategyBaseTVLLimits baseStrategyImplementation = StrategyBaseTVLLimits(
             stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.baseStrategyImplementation")
         );
+        IRewardsCoordinator rewardsCoordinator =
+            IRewardsCoordinator(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.rewardsCoordinator"));
 
         address credibleSquaringCommunityMultisig = msg.sender;
         address credibleSquaringPauser = msg.sender;
@@ -97,6 +99,7 @@ contract IncredibleSquaringDeployer is Script, Utils {
         _deployCredibleSquaringContracts(
             delegationManager,
             avsDirectory,
+            rewardsCoordinator,
             erc20MockStrategy,
             credibleSquaringCommunityMultisig,
             credibleSquaringPauser
@@ -138,6 +141,7 @@ contract IncredibleSquaringDeployer is Script, Utils {
     function _deployCredibleSquaringContracts(
         IDelegationManager delegationManager,
         IAVSDirectory avsDirectory,
+        IRewardsCoordinator rewardsCoordinator,
         IStrategy strat,
         address incredibleSquaringCommunityMultisig,
         address credibleSquaringPauser
@@ -265,7 +269,7 @@ contract IncredibleSquaringDeployer is Script, Utils {
         }
 
         incredibleSquaringServiceManagerImplementation = new IncredibleSquaringServiceManager(
-            avsDirectory, registryCoordinator, stakeRegistry, incredibleSquaringTaskManager
+            avsDirectory, rewardsCoordinator, registryCoordinator, stakeRegistry, incredibleSquaringTaskManager
         );
         // Third, upgrade the proxy contracts to use the correct implementation contracts and initialize them.
         incredibleSquaringProxyAdmin.upgrade(

--- a/contracts/src/IncredibleSquaringServiceManager.sol
+++ b/contracts/src/IncredibleSquaringServiceManager.sol
@@ -25,17 +25,11 @@ contract IncredibleSquaringServiceManager is ServiceManagerBase {
 
     constructor(
         IAVSDirectory _avsDirectory,
+        IRewardsCoordinator _rewardsCoordinator,
         IRegistryCoordinator _registryCoordinator,
         IStakeRegistry _stakeRegistry,
         IIncredibleSquaringTaskManager _incredibleSquaringTaskManager
-    )
-        ServiceManagerBase(
-            _avsDirectory,
-            IPaymentCoordinator(address(0)), // inc-sq doesn't need to deal with payments
-            _registryCoordinator,
-            _stakeRegistry
-        )
-    {
+    ) ServiceManagerBase(_avsDirectory, _rewardsCoordinator, _registryCoordinator, _stakeRegistry) {
         incredibleSquaringTaskManager = _incredibleSquaringTaskManager;
     }
 


### PR DESCRIPTION
## Description

This PR updates contracts to use [eigenlayer-middleware v0.2.1](https://github.com/Layr-Labs/eigenlayer-middleware/releases/tag/v0.2.1-mainnet-rewards).

NOTE: It modifies the deployment script to dynamically retrieve the `rewardsCoordinator` address using the path `.addresses.rewardsCoordinator` from the `eigenlayerDeployedContracts` configuration:
```
IRewardsCoordinator(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.rewardsCoordinator"));
```
