### PR TITLE
ci: add workflow to run end-to-end test

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -27,6 +27,9 @@ jobs:
           # - ref: slashing-magnitudes
           #   version: v1.0.3
 
+    permissions:
+      contents: read
+
     name: End-to-end test
     runs-on: ubuntu-latest
     steps:
@@ -52,15 +55,10 @@ jobs:
           echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
 
       # Install the devnet
-      # TODO: use action when available
-      - uses: actions/checkout@v4
-        with:
-          repository: Layr-Labs/avs-devnet
-          path: avs-devnet
-
       - name: Install devnet
-        working-directory: avs-devnet
-        run: make install
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/Layr-Labs/avs-devnet/main/install.sh | sh -s -- "v0.1.0-rc.3"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
 
       # Checkout repo
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,10 +16,15 @@ jobs:
           - ref: v0.3.3-mainnet-rewards
             version: v0.3.3
           # TODO: fix these
-          # Rewards v2
+          # # Rewards v1
+          # # Doesn't compile
+          # - ref: v0.4.3-mainnet-rewards-foundation-incentives
+          #   version: v0.4.3
+          # # Rewards v2
+          # # Devnet has problems running it
           # - ref: v0.5.3
           #   version: v0.5.3
-          # Newest testnet release
+          # # Isn't supported by ICS yet
           # - ref: slashing-magnitudes
           #   version: v1.0.3
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -22,10 +22,7 @@ jobs:
     name: End-to-end test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
+      # Install foundry, go, ko, and kurtosis
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -37,7 +34,34 @@ jobs:
 
       - uses: ko-build/setup-ko@v0.7
 
+      - name: Install Kurtosis
+        shell: bash
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli
+          kurtosis analytics disable
+          echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
+
+      # Install the devnet
+      # TODO: use action when available
+      - uses: actions/checkout@v4
+        with:
+          repository: Layr-Labs/avs-devnet
+          path: avs-devnet
+
+      - name: Install devnet
+        working-directory: avs-devnet
+        run: make install
+
+      # Checkout repo
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: ics
+
       - name: Run end-to-end test
+        working-directory: ics
         run: |
           export EL_REF=${{ matrix.el-contracts.ref }}
           export EL_VERSION=${{ matrix.el-contracts.version }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -15,6 +15,9 @@ jobs:
           # Mainnet version isn't used because of compile errors
           - ref: v0.3.3-mainnet-rewards
             version: v0.3.3
+          # Rewards v2
+          - ref: v0.5.3
+            version: v0.5.3
           # Newest testnet release
           - ref: slashing-magnitudes
             version: v1.0.3

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+env:
+  KURTOSIS_VERSION: "1.4.4"
+  DEVNET_VERSION: "v0.1.0-rc.3"
+
 jobs:  
   e2e:
     strategy:
@@ -50,14 +54,14 @@ jobs:
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          sudo apt install kurtosis-cli
+          sudo apt install -y kurtosis-cli=${{env.KURTOSIS_VERSION}}
           kurtosis analytics disable
           echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
 
       # Install the devnet
       - name: Install devnet
         run: |
-          curl -sSfL https://raw.githubusercontent.com/Layr-Labs/avs-devnet/main/install.sh | sh -s -- "v0.1.0-rc.3"
+          curl -sSfL https://raw.githubusercontent.com/Layr-Labs/avs-devnet/main/install.sh | sh -s -- ${{env.DEVNET_VERSION}}
           echo "$HOME/bin" >> "$GITHUB_PATH"
 
       # Checkout repo

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -15,12 +15,13 @@ jobs:
           # Mainnet version isn't used because of compile errors
           - ref: v0.3.3-mainnet-rewards
             version: v0.3.3
+          # TODO: fix these
           # Rewards v2
-          - ref: v0.5.3
-            version: v0.5.3
+          # - ref: v0.5.3
+          #   version: v0.5.3
           # Newest testnet release
-          - ref: slashing-magnitudes
-            version: v1.0.3
+          # - ref: slashing-magnitudes
+          #   version: v1.0.3
 
     name: End-to-end test
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -17,7 +17,7 @@ jobs:
             version: v0.3.3
           # TODO: fix these
           # # Rewards v1
-          # # Doesn't compile
+          # # "delegation" was renamed to "delegationManager" in addresses JSON
           # - ref: v0.4.3-mainnet-rewards-foundation-incentives
           #   version: v0.4.3
           # # Rewards v2

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,0 +1,44 @@
+name: End-to-end tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:  
+  e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        el-contracts:
+          # Mainnet version isn't used because of compile errors
+          - ref: v0.3.3-mainnet-rewards
+            version: v0.3.3
+          # Newest testnet release
+          - ref: slashing-magnitudes
+            version: v1.0.3
+
+    name: End-to-end test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - uses: ko-build/setup-ko@v0.7
+
+      - name: Run end-to-end test
+        run: |
+          export EL_REF=${{ matrix.el-contracts.ref }}
+          export EL_VERSION=${{ matrix.el-contracts.version }}
+          ./scripts/e2e_test.sh

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,7 +21,7 @@ jobs:
           # - ref: v0.4.3-mainnet-rewards-foundation-incentives
           #   version: v0.4.3
           # # Rewards v2
-          # # Devnet has problems running it
+          # # "delegation" was renamed to "delegationManager" in addresses JSON
           # - ref: v0.5.3
           #   version: v0.5.3
           # # Isn't supported by ICS yet

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -15,16 +15,15 @@ jobs:
           # Mainnet version isn't used because of compile errors
           - ref: v0.3.3-mainnet-rewards
             version: v0.3.3
+          # All of them fail because "delegation" was renamed to "delegationManager" in the addresses JSON
           # TODO: fix these
           # # Rewards v1
-          # # "delegation" was renamed to "delegationManager" in addresses JSON
           # - ref: v0.4.3-mainnet-rewards-foundation-incentives
           #   version: v0.4.3
           # # Rewards v2
-          # # "delegation" was renamed to "delegationManager" in addresses JSON
           # - ref: v0.5.3
           #   version: v0.5.3
-          # # Isn't supported by ICS yet
+          # # Slashing
           # - ref: slashing-magnitudes
           #   version: v1.0.3
 

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# TODO: we could speed this up by making the block times configurable
+#  then we can use lower block times in the devnet, and reduce both startup and sleep times
+
+# This script receives the EL contract version to test against
+# In case they aren't specified, we use a default one
+DEFAULT_REF=v0.3.3-mainnet-rewards
+EL_REF="${EL_REF:-$DEFAULT_REF}"
+EL_VERSION="${EL_VERSION:-$EL_REF}"
+
+set -e -o nounset
+
+# This is so the script can be called from anywhere
+parent_path=$(
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    pwd -P
+)
+cd $parent_path/..
+
+
+# Stop the devnet in case it's already running
+devnet stop || true
+
+cp devnet.yaml devnet.yaml.bak
+
+# Update the devnet configuration with the EL contract versions to test against
+if [[ $EL_REF != $DEFAULT_REF ]] ; then
+    yq -i ".deployments.0.ref = \"$EL_REF\"" devnet.yaml
+    yq -i ".deployments.0.version = \"$EL_VERSION\"" devnet.yaml
+fi
+
+# Stop the devnet after we finish
+cleanup() {
+    echo "Executing cleanup function..."
+    set +e
+    # Stop the devnet, and restore the old devnet configuration
+    devnet stop || true
+    mv devnet.yaml.bak devnet.yaml || true
+}
+trap 'cleanup' EXIT
+
+# Start the devnet and exit with a custom message if it fails
+devnet start || { echo "Failed to start the devnet" ; exit 42; }
+
+# Fetch RPC URL and TaskManager address
+RPC_URL=$(devnet get-ports | yq .el-1-besu-lighthouse.rpc)
+echo "Fetched RPC URL: $RPC_URL"
+
+TASK_MANAGER_ADDR=$(devnet get-address avs_addresses:credibleSquaringTaskManager)
+echo "Fetched TaskManager address: $TASK_MANAGER_ADDR"
+
+# Fetch the latest task number
+echo "Fetching latest task number..."
+LATEST_TASK_NUM=$(cast call --rpc-url $RPC_URL $TASK_MANAGER_ADDR 'latestTaskNum()(uint32)')
+
+echo -n "Got: $LATEST_TASK_NUM. "
+
+# Check that task number is a number
+case $LATEST_TASK_NUM in
+    ''|*[!0-9]*) echo "Invalid task number" ; exit 1 ;;
+    *) echo "OK" ;;
+esac
+
+
+# Sleep until the task is completed
+# TODO: in paper, this should take only 2 blocks (24s), but it takes more sometimes. Is that OK?
+SLEEP_TIME=60
+echo "Sleeping for ${SLEEP_TIME}s so the AVS completes the task"
+sleep $SLEEP_TIME
+
+
+# Fetch the task response hash
+echo "Fetching task response $LATEST_TASK_NUM..."
+SOME_RESPONSE=$(cast call --rpc-url $RPC_URL $TASK_MANAGER_ADDR 'allTaskResponses(uint32)(bytes32)' $LATEST_TASK_NUM)
+
+echo -n "Got: $SOME_RESPONSE. "
+
+EMPTY_RESPONSE="0x0000000000000000000000000000000000000000000000000000000000000000"
+
+# Check the task response hash is a 32 bytes hexstring
+if [[ "$SOME_RESPONSE" =~ ^0x[0-9A-Fa-f]{64}$ ]]; then
+    # Check that task number is non-empty
+    if [[ "$SOME_RESPONSE" == "$EMPTY_RESPONSE" ]]; then
+        echo "Empty response"
+        exit 2
+    fi
+    echo "OK"
+else
+    echo "Invalid task response"
+    exit 3
+fi

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -20,7 +20,7 @@ cd $parent_path/..
 
 
 # Stop the devnet in case it's already running
-devnet stop || true
+avs-devnet stop || true
 
 cp devnet.yaml devnet.yaml.bak
 
@@ -35,19 +35,19 @@ cleanup() {
     echo "Executing cleanup function..."
     set +e
     # Stop the devnet, and restore the old devnet configuration
-    devnet stop || true
+    avs-devnet stop || true
     mv devnet.yaml.bak devnet.yaml || true
 }
 trap 'cleanup' EXIT
 
 # Start the devnet and exit with a custom message if it fails
-devnet start || { echo "Failed to start the devnet" ; exit 42; }
+avs-devnet start || { echo "Failed to start the devnet" ; exit 42; }
 
 # Fetch RPC URL and TaskManager address
-RPC_URL=$(devnet get-ports | yq .el-1-besu-lighthouse.rpc)
+RPC_URL=$(avs-devnet get-ports | yq .el-1-besu-lighthouse.rpc)
 echo "Fetched RPC URL: $RPC_URL"
 
-TASK_MANAGER_ADDR=$(devnet get-address avs_addresses:credibleSquaringTaskManager)
+TASK_MANAGER_ADDR=$(avs-devnet get-address avs_addresses:credibleSquaringTaskManager)
 echo "Fetched TaskManager address: $TASK_MANAGER_ADDR"
 
 # Fetch the latest task number


### PR DESCRIPTION
Depends on #105

This PR:
- adds a script that uses the devnet to run an end-to-end test
- adds an Actions workflow that runs the script with `v0.3.3` of core contracts deployed

Some versions on the job matrix are commented out because of errors. All of rewards v1, rewards v2, and slashing use a different name for the `DelegationManager` address in the JSON output of the deployment script than expected (`delegationManager`, instead of `delegation`). To fix this, we need to change the AVS deployment scripts to use the new name.