### PR TITLE
ci: bump actions versions

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: '1.21.x'
       - uses: actions/checkout@v4
 
-      - uses: ko-build/setup-ko@v0.7
+      - uses: ko-build/setup-ko@v0.8
       # We build both the aggregator and the operator in the same job
       # we could separate them, but anyways they share core/ so it would get messy
       # See https://ko.build/configuration/#naming-images to understand --preserve-import-paths

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: '1.21.x'
       - uses: actions/checkout@v4
 
-      - uses: ko-build/setup-ko@v0.8
+      - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8
       # We build both the aggregator and the operator in the same job
       # we could separate them, but anyways they share core/ so it would get messy
       # See https://ko.build/configuration/#naming-images to understand --preserve-import-paths

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -16,12 +16,12 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21.x'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: ko-build/setup-ko@v0.6
+      - uses: ko-build/setup-ko@v0.7
       # We build both the aggregator and the operator in the same job
       # we could separate them, but anyways they share core/ so it would get messy
       # See https://ko.build/configuration/#naming-images to understand --preserve-import-paths

--- a/.github/workflows/contracts-tests.yml
+++ b/.github/workflows/contracts-tests.yml
@@ -11,12 +11,12 @@ jobs:
     name: Contracts Forge Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Install forge dependencies
         run: forge install

--- a/.github/workflows/daily-test.yaml
+++ b/.github/workflows/daily-test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run Forge build
         run: |

--- a/.github/workflows/docker-compose-up-test.yaml
+++ b/.github/workflows/docker-compose-up-test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run Docker Compose
         run: docker compose up -d

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3
         with:
           install: true
           driver-opts: >-
@@ -39,7 +39,7 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -19,17 +19,17 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
           driver-opts: >-
             image=moby/buildkit:master
 
       - name: Cache main image layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -39,7 +39,7 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,8 +11,8 @@ jobs:
     name: Integration Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
       
@@ -20,7 +20,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
       - name: Install forge dependencies
         run: forge install
         working-directory: ./contracts

--- a/.github/workflows/storage-checker.yaml
+++ b/.github/workflows/storage-checker.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: "Generate and prepare the contract artifacts"
         run: |

--- a/.github/workflows/storage-checker.yaml
+++ b/.github/workflows/storage-checker.yaml
@@ -20,7 +20,7 @@ jobs:
           cd contracts && mkdir pr
           for file in $(find src -name '*.sol'); do
               contract_name=$(basename "$file" .sol)
-              forge inspect "$contract_name" storage --pretty > pr/"$contract_name".md
+              forge inspect --pretty "$contract_name" storage > pr/"$contract_name".md
           done
 
       - name: Checkout Base Branch
@@ -35,7 +35,7 @@ jobs:
           cd contracts && mkdir base
           for file in $(find src -name '*.sol'); do
               contract_name=$(basename "$file" .sol)
-              forge inspect "$contract_name" storage --pretty > base/"$contract_name".md
+              forge inspect --pretty "$contract_name" storage > base/"$contract_name".md
           done
       - name: Compare outputs
         run: |

--- a/.github/workflows/storage-checker.yaml
+++ b/.github/workflows/storage-checker.yaml
@@ -20,7 +20,7 @@ jobs:
           cd contracts && mkdir pr
           for file in $(find src -name '*.sol'); do
               contract_name=$(basename "$file" .sol)
-              forge inspect --pretty "$contract_name" storage > pr/"$contract_name".md
+              forge inspect "$contract_name" storage > pr/"$contract_name".md
           done
 
       - name: Checkout Base Branch
@@ -35,7 +35,7 @@ jobs:
           cd contracts && mkdir base
           for file in $(find src -name '*.sol'); do
               contract_name=$(basename "$file" .sol)
-              forge inspect --pretty "$contract_name" storage > base/"$contract_name".md
+              forge inspect "$contract_name" storage > base/"$contract_name".md
           done
       - name: Compare outputs
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,8 +11,8 @@ jobs:
     name: Unit Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
       - name: Test


### PR DESCRIPTION
This PR fixes the docker publishing workflow by bumping `actions/cache` from v2 to v4. It also bumps all other actions to the latest major version.