### PR TITLE
fix: update broken link Utils.sol

### DIFF
--- a/contracts/script/utils/Utils.sol
+++ b/contracts/script/utils/Utils.sol
@@ -46,7 +46,7 @@ contract Utils is Script {
         }
     }
 
-    // Forge scripts best practice: https://book.getfoundry.sh/tutorials/best-practices#scripts
+    // Forge scripts best practice: https://book.getfoundry.sh/guides/best-practices#scripts
     function readInput(
         string memory inputFileName
     ) internal view returns (string memory) {


### PR DESCRIPTION
I fixes a broken link in the `Utils.sol` contract. The outdated link to Foundry's best practices for scripts has been updated to the correct URL.

- Updated the link
from:  
  `https://book.getfoundry.sh/tutorials/best-practices#scripts`  
to:  
  `https://book.getfoundry.sh/guides/best-practices#scripts`.
