### PR TITLE
fix: export `PRIVATE_KEY` env var in deploy scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,6 @@ create-quorum:
 uam-permissions:
 	./tests/anvil/uam-permissions.sh
 
-deploy-el-and-avs-contracts: deploy-eigenlayer deploy-avs
-
 deploy-all: deploy-eigenlayer deploy-avs uam-permissions create-quorum
 
 bindings: ## generates contract bindings

--- a/tests/anvil/create-quorum.sh
+++ b/tests/anvil/create-quorum.sh
@@ -1,6 +1,6 @@
 
 RPC_URL=http://localhost:8545
-PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 # cd to the directory of this script so that this can be run from anywhere
 parent_path=$(

--- a/tests/anvil/deploy-avs.sh
+++ b/tests/anvil/deploy-avs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RPC_URL=http://localhost:8545
-PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 # cd to the directory of this script so that this can be run from anywhere
 parent_path=$(

--- a/tests/anvil/deploy-eigenlayer.sh
+++ b/tests/anvil/deploy-eigenlayer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RPC_URL=http://localhost:8545
-PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 # Navigate to the script directory
 parent_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
@@ -12,4 +12,3 @@ root_dir=$(realpath "$parent_path/../..")
 # Deploy Contracts
 cd "$root_dir/contracts"
 forge script script/DeployEigenLayerCore.s.sol:DeployEigenLayerCore --rpc-url $RPC_URL --broadcast --private-key $PRIVATE_KEY 
-

--- a/tests/anvil/dump-state.sh
+++ b/tests/anvil/dump-state.sh
@@ -30,8 +30,3 @@ forge script script/IncredibleSquaringDeployer.s.sol --rpc-url $RPC_URL --privat
 forge script script/UAMPermissions.s.sol --rpc-url $RPC_URL --broadcast --slow --private-key $PRIVATE_KEY
 
 forge script script/CreateQuorum.s.sol --rpc-url $RPC_URL --broadcast --slow --private-key $PRIVATE_KEY
-
-# TODO(nova) this fails if we run all together with arithmetic underlow or overflow in createAVSRewardsSubmission
-# forge script script/SetupPayments.s.sol --rpc-url $RPC_URL --broadcast --private-key $PRIVATE_KEY  -vvv
-
-# forge script script/OperatorDirectedPayments.s.sol --rpc-url $RPC_URL --broadcast --slow --private-key $PRIVATE_KEY

--- a/tests/anvil/dump-state.sh
+++ b/tests/anvil/dump-state.sh
@@ -13,7 +13,7 @@ set -a
 source $parent_path/utils.sh
 # we overwrite some variables here because should always deploy to anvil (localhost)
 RPC_URL=http://localhost:8545
-PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 set +a
 
 

--- a/tests/anvil/uam-permissions.sh
+++ b/tests/anvil/uam-permissions.sh
@@ -1,6 +1,7 @@
+#!/bin/bash
 
 RPC_URL=http://localhost:8545
-PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 # cd to the directory of this script so that this can be run from anywhere
 parent_path=$(


### PR DESCRIPTION
This PR fixes errors in the deploy scripts because `PRIVATE_KEY` wasn't being loaded into the environment.